### PR TITLE
Support download from registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Bug Fixes
 
-* None.  
+* Ensure that the non-compilable resource skipping in static frameworks happens only for the pod itself  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#9922](https://github.com/CocoaPods/CocoaPods/pull/9922)
+  [#9920](https://github.com/CocoaPods/CocoaPods/issues/9920)
 
 
 ## 1.10.0.beta.1 (2020-07-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To install release candidates run `[sudo] gem install cocoapods --pre`
 
 ##### Enhancements
 
-* None.  
+* Support for CocoaPods registries.
+  [yahavi](https://github.com/yahavi)
+  [#9959](https://github.com/CocoaPods/CocoaPods/pull/9959)
 
 ##### Bug Fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,6 @@ PATH
   remote: .
   specs:
     cocoapods (1.10.0.beta.1)
-      activesupport (> 5)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
       cocoapods-core (= 1.10.0.beta.1)

--- a/cocoapods.gemspec
+++ b/cocoapods.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'molinillo',             '~> 0.6.6'
   s.add_runtime_dependency 'xcodeproj',             '>= 1.17.0', '< 2.0'
 
-  s.add_runtime_dependency 'activesupport', '> 5'
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'escape',        '~> 0.0.4'
   s.add_runtime_dependency 'fourflusher',   '>= 2.3.0', '< 3.0'

--- a/lib/cocoapods/command/repo.rb
+++ b/lib/cocoapods/command/repo.rb
@@ -22,6 +22,9 @@ module Pod
       extend Executable
       executable :git
 
+      extend Executable
+      executable :curl
+
       def dir
         config.repos_dir + @name
       end

--- a/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator/pod_target_installer.rb
@@ -355,7 +355,7 @@ module Pod
               filter_resource_file_references(file_accessor.resources.flatten) do |compile_phase_refs, resource_phase_refs|
                 native_target.add_file_references(compile_phase_refs, nil)
 
-                if target.build_as_static_framework?
+                if target.build_as_static_framework? && consumer.spec.library_specification?
                   resource_phase_refs = resource_phase_refs.select { |ref| Target.resource_extension_compilable?(File.extname(ref.path)) }
                 end
 

--- a/spec/functional/command/repo/add_spec.rb
+++ b/spec/functional/command/repo/add_spec.rb
@@ -35,6 +35,14 @@ module Pod
       Dir.chdir(repo2.dir) { `git symbolic-ref HEAD` }.should.include? 'my-branch'
     end
 
+    it 'adds a registry repo' do
+      run_command('repo', 'add', 'registry', 'https://github.com/CocoaPods/cocoapods-test-specs/archive/master.zip', '--registry')
+      Dir.chdir(config.repos_dir + 'registry') do
+        registry_rc = YAML.safe_load(File.read('.registry-rc.yml'))
+        registry_rc['registry_url'].chomp.should == 'https://github.com/CocoaPods/cocoapods-test-specs/archive/master.zip'
+      end
+    end
+
     it 'raises an informative error when the repos directory fails to be created' do
       repos_dir = config.repos_dir
       def repos_dir.mkpath

--- a/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
+++ b/spec/unit/installer/xcode/pods_project_generator/pod_target_installer_spec.rb
@@ -547,6 +547,18 @@ module Pod
                 end
               end
 
+              it 'adds the resources to the copy resources phase for test target when a pod target is a static framework' do
+                @watermelon_ios_pod_target.stubs(:build_type => BuildType.static_framework)
+                @ios_installer.install!
+
+                unit_test_target = @project.targets.find { |t| t.name == 'WatermelonLib-Unit-Tests' }
+
+                resources = unit_test_target.resources_build_phase.files
+                resources.count.should > 0
+                resource = resources.find { |res| res.file_ref.path.include?('resource.txt') }
+                resource.should.be.not.nil
+              end
+
               it 'adds the resources bundles to the copy resources script for app target' do
                 @ios_installer.install!
                 script_path = @watermelon_ios_pod_target.copy_resources_script_path_for_spec(@watermelon_spec.app_specs.first)


### PR DESCRIPTION
Cocoapods core PR: https://github.com/yahavi/Core/pull/1

### Installation:
#### Install prerequisites:
1. Run `sudo gem install rake:10.5.0 bundler bundler:1.17.3`
2. Clone [Rainforest](https://github.com/CocoaPods/Rainforest)
3. CD to Rainforest and run `sudo rake bootstrap` - this should install the required gems.

#### Install Core:
1. Clone [Core](https://github.com/yahavi/Core/tree/registry) and checkout to 'registry' branch.
2. CD to `Core`
3. Run:
```
sudo rake bootstrap
sudo rake install
sudo gem install ./pkg/cocoapods-core-1.9.3.gem
``` 

#### Install Cocoapods
1. Clone [CocoaPods](https://github.com/yahavi/CocoaPods/tree/registry) and checkout to 'registry' branch.
2. CD to `CocoaPods` 
3. Run:
```
sudo bundle install 
sudo rake install
sudo gem install ./pkg/cocoapods-1.9.3.gem
```

### Usage:

1. Add Artifactory repository
```
pod repo add art-repo https://ecosysjfrog.jfrog.io/artifactory/api/pods/cocoapods-remote/index/fetchIndex --registry
```
2. Add artifactory repo to the podfile:
```
source 'https://ecosysjfrog.jfrog.io/artifactory/api/pods/cocoapods-remote/index/fetchIndex'
```
Alternatively, use this example:  https://github.com/yahavi/CocoapodsExample
3. CD to the Podfile directory:
```
cd Example
```
4. Run pod install and make sure the pods are downloaded from Artifactory.